### PR TITLE
Add API key management and GitHub integration

### DIFF
--- a/app/components/SettingsContent.client.tsx
+++ b/app/components/SettingsContent.client.tsx
@@ -3,6 +3,7 @@ import { ApiKeyCard } from '~/components/settings/ApiKeyCard';
 import { ThemeCard } from '~/components/settings/ThemeCard';
 import { ProfileCard } from '~/components/settings/ProfileCard';
 import { UsageCard } from '~/components/settings/UsageCard';
+import { GithubConnectCard } from '~/components/settings/GithubConnectCard';
 import { Toaster } from '~/components/ui/Toaster';
 import { UserProvider } from '~/components/UserProvider';
 
@@ -21,6 +22,7 @@ export function SettingsContent() {
           <div className="space-y-6">
             <ProfileCard />
             <UsageCard />
+            <GithubConnectCard />
             <ApiKeyCard />
             <ThemeCard />
           </div>

--- a/app/components/settings/GithubConnectCard.tsx
+++ b/app/components/settings/GithubConnectCard.tsx
@@ -1,0 +1,133 @@
+import { useQuery, useConvex } from 'convex/react';
+import { api } from '@convex/_generated/api';
+import { Button } from '@ui/Button';
+import { useEffect, useState } from 'react';
+import { Spinner } from '@ui/Spinner';
+import JSZip from 'jszip';
+import { webcontainer } from '~/lib/webcontainer';
+import { WORK_DIR } from 'chef-agent/constants';
+import { path } from 'chef-agent/utils/path';
+
+export function GithubConnectCard() {
+  const convex = useConvex();
+  const connection = useQuery(api.github.getConnection);
+  const [repos, setRepos] = useState<Array<{ id: number; full_name: string }>>([]);
+  const [loadingRepos, setLoadingRepos] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      if (connection?.connected) {
+        setLoadingRepos(true);
+        try {
+          const list = await convex.action(api.github.listRepos, {});
+          setRepos(list.map((r) => ({ id: r.id, full_name: r.full_name })));
+        } finally {
+          setLoadingRepos(false);
+        }
+      } else {
+        setRepos([]);
+      }
+    };
+    load();
+  }, [connection?.connected, convex]);
+
+  const connect = () => {
+    window.location.href = '/github/connect';
+  };
+
+  const disconnect = async () => {
+    await convex.mutation(api.github.disconnect, {});
+  };
+
+  return (
+    <div className="rounded-lg border bg-bolt-elements-background-depth-1 shadow-sm">
+      <div className="p-6">
+        <h2 className="mb-2 text-xl font-semibold text-content-primary">GitHub</h2>
+        {!connection && <div className="h-[78px] w-full animate-pulse rounded-lg bg-gray-200 dark:bg-gray-700" />}
+        {connection && !connection.connected && (
+          <div className="flex items-center gap-2 py-1.5">
+            <Button onClick={connect}>Connect GitHub</Button>
+          </div>
+        )}
+        {connection && connection.connected && (
+          <div className="space-y-3">
+            <div className="flex items-center gap-3">
+              {connection.avatarUrl && (
+                <img src={connection.avatarUrl} className="size-8 rounded-full" alt="avatar" />
+              )}
+              <div className="text-sm text-content-secondary">Connected as {connection.username ?? 'GitHub user'}</div>
+              <Button variant="danger" onClick={disconnect} inline>
+                Disconnect
+              </Button>
+            </div>
+            <div>
+              <div className="mb-2 text-sm font-medium text-content-primary">Your repositories</div>
+              {loadingRepos ? (
+                <Spinner />
+              ) : repos.length === 0 ? (
+                <div className="text-sm text-content-secondary">No repositories found.</div>
+              ) : (
+                <ul className="max-h-60 divide-y overflow-auto rounded border">
+                  {repos.map((r) => (
+                    <li key={r.id} className="flex items-center justify-between gap-3 p-2">
+                      <span className="truncate text-sm">{r.full_name}</span>
+                      <Button
+                        onClick={() => importRepo(r.full_name)}
+                        variant="neutral"
+                        inline
+                      >
+                        Import
+                      </Button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+  async function importRepo(fullName: string) {
+    const wc = await webcontainer;
+    // Download archive bytes from Convex
+    const bytes = await convex.action(api.github.downloadRepoArchive, { fullName });
+    const zip = await JSZip.loadAsync(bytes as unknown as ArrayBuffer);
+    // Determine root folder prefix
+    let rootPrefix = '';
+    zip.forEach((relativePath) => {
+      if (!rootPrefix) {
+        const parts = relativePath.split('/');
+        if (parts.length > 1) {
+          rootPrefix = parts[0] + '/';
+        }
+      }
+    });
+    const ensureDir = async (dirPath: string) => {
+      try {
+        await wc.fs.mkdir(dirPath, { recursive: true } as any);
+      } catch (e) {
+        // ignore if exists
+      }
+    };
+    const writes: Array<Promise<unknown>> = [];
+    await Promise.all(
+      Object.keys(zip.files).map(async (filePath) => {
+        const entry = zip.files[filePath];
+        if (!entry || entry.dir) return;
+        // Strip root folder
+        const relative = rootPrefix && filePath.startsWith(rootPrefix) ? filePath.slice(rootPrefix.length) : filePath;
+        if (!relative) return;
+        const targetPath = path.join(WORK_DIR, relative);
+        const dir = path.dirname(targetPath);
+        await ensureDir(dir);
+        const content = await entry.async('uint8array');
+        writes.push(wc.fs.writeFile(targetPath, content));
+      }),
+    );
+    await Promise.all(writes);
+    // Simple feedback
+    alert(`Imported ${fullName} into workspace.`);
+  }
+}
+

--- a/app/lib/webcontainer/index.ts
+++ b/app/lib/webcontainer/index.ts
@@ -51,6 +51,19 @@ if (shouldBootWebcontainer) {
         webcontainer.on('preview-message', (message) => {
           logger.info('WebContainer preview message:', JSON.stringify(message));
 
+          // Handle custom messages for GitHub import
+          if ((message as any).type === 'chef:import-github' && typeof (message as any).fullName === 'string') {
+            // TODO: Implement fetch and extraction of repo contents via GitHub API
+            // For now, just surface an alert that import is not yet implemented.
+            workbenchStore.actionAlert.set({
+              type: 'preview',
+              title: 'Import from GitHub',
+              description: `Requested import for ${(message as any).fullName}.`,
+              content: 'Import flow will fetch a repo archive and write files into your workspace.',
+              source: 'preview',
+            });
+          }
+
           // Handle both uncaught exceptions and unhandled promise rejections
           if (message.type === 'PREVIEW_UNCAUGHT_EXCEPTION' || message.type === 'PREVIEW_UNHANDLED_REJECTION') {
             const isPromise = message.type === 'PREVIEW_UNHANDLED_REJECTION';

--- a/app/routes/github.callback.tsx
+++ b/app/routes/github.callback.tsx
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+import { useSearchParams } from '@remix-run/react';
+import { Spinner } from '@ui/Spinner';
+import { useConvex } from 'convex/react';
+import { api } from '@convex/_generated/api';
+
+export default function GithubCallback() {
+  const convex = useConvex();
+  const [params] = useSearchParams();
+
+  useEffect(() => {
+    const run = async () => {
+      const code = params.get('code');
+      const error = params.get('error');
+      if (error) {
+        window.location.replace('/settings?githubError=' + encodeURIComponent(error));
+        return;
+      }
+      if (!code) {
+        window.location.replace('/settings?githubError=missing_code');
+        return;
+      }
+      const origin = window.location.origin;
+      const { accessToken, username, avatarUrl } = await convex.action(api.github.exchangeCode, {
+        code,
+        redirectUri: `${origin}/github/callback`,
+      });
+      await convex.mutation(api.github.saveAccessToken, { accessToken, username, avatarUrl });
+      window.location.replace('/settings');
+    };
+    run();
+  }, [convex, params]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center" style={{ backgroundColor: '#f9f7ee' }}>
+      <Spinner />
+    </div>
+  );
+}
+

--- a/app/routes/github.connect.tsx
+++ b/app/routes/github.connect.tsx
@@ -1,0 +1,25 @@
+import type { LoaderFunctionArgs } from '@vercel/remix';
+import { redirect } from '@vercel/remix';
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  const origin = url.origin;
+  const clientId = process.env.GITHUB_CLIENT_ID;
+  if (!clientId) {
+    throw new Response('Missing GITHUB_CLIENT_ID', { status: 500 });
+  }
+  const state = crypto.randomUUID();
+  const scopes = ['repo', 'read:user'];
+  const redirectUri = `${origin}/github/callback`;
+  const authUrl = new URL('https://github.com/login/oauth/authorize');
+  authUrl.searchParams.set('client_id', clientId);
+  authUrl.searchParams.set('redirect_uri', redirectUri);
+  authUrl.searchParams.set('scope', scopes.join(' '));
+  authUrl.searchParams.set('state', state);
+  return redirect(authUrl.toString());
+}
+
+export default function GithubConnect() {
+  return null;
+}
+

--- a/convex/github.ts
+++ b/convex/github.ts
@@ -1,0 +1,173 @@
+"use node";
+import { action, mutation, query } from "./_generated/server";
+import { v, ConvexError } from "convex/values";
+
+export const getConnection = query({
+  args: {},
+  returns: v.union(
+    v.null(),
+    v.object({
+      connected: v.literal(true),
+      username: v.optional(v.string()),
+      avatarUrl: v.optional(v.string()),
+    }),
+  ),
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return null;
+    const member = await ctx.db
+      .query("convexMembers")
+      .withIndex("byConvexMemberId", (q) => q.eq("convexMemberId", identity.subject))
+      .first();
+    if (!member || !member.github) return null;
+    return { connected: true as const, username: member.github.username, avatarUrl: member.github.avatarUrl };
+  },
+});
+
+export const saveAccessToken = mutation({
+  args: {
+    accessToken: v.string(),
+    username: v.optional(v.string()),
+    avatarUrl: v.optional(v.string()),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new ConvexError({ code: "NotAuthorized", message: "Unauthorized" });
+    const member = await ctx.db
+      .query("convexMembers")
+      .withIndex("byConvexMemberId", (q) => q.eq("convexMemberId", identity.subject))
+      .first();
+    if (!member) throw new ConvexError({ code: "NotAuthorized", message: "Unauthorized" });
+    await ctx.db.patch(member._id, {
+      github: { accessToken: args.accessToken, username: args.username, avatarUrl: args.avatarUrl },
+    });
+    return null;
+  },
+});
+
+export const disconnect = mutation({
+  args: {},
+  returns: v.null(),
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new ConvexError({ code: "NotAuthorized", message: "Unauthorized" });
+    const member = await ctx.db
+      .query("convexMembers")
+      .withIndex("byConvexMemberId", (q) => q.eq("convexMemberId", identity.subject))
+      .first();
+    if (!member) throw new ConvexError({ code: "NotAuthorized", message: "Unauthorized" });
+    await ctx.db.patch(member._id, { github: undefined });
+    return null;
+  },
+});
+
+export const exchangeCode = action({
+  args: {
+    code: v.string(),
+    redirectUri: v.string(),
+  },
+  returns: v.object({ accessToken: v.string(), username: v.optional(v.string()), avatarUrl: v.optional(v.string()) }),
+  handler: async (ctx, args) => {
+    const clientId = process.env.GITHUB_CLIENT_ID;
+    const clientSecret = process.env.GITHUB_CLIENT_SECRET;
+    if (!clientId || !clientSecret) {
+      throw new Error("Missing GITHUB_CLIENT_ID or GITHUB_CLIENT_SECRET");
+    }
+
+    const tokenResp = await fetch("https://github.com/login/oauth/access_token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify({ client_id: clientId, client_secret: clientSecret, code: args.code, redirect_uri: args.redirectUri }),
+    });
+    if (!tokenResp.ok) {
+      throw new Error(`GitHub token exchange failed: ${await tokenResp.text()}`);
+    }
+    const tokenJson = (await tokenResp.json()) as { access_token?: string; token_type?: string; scope?: string };
+    if (!tokenJson.access_token) {
+      throw new Error("No access_token in GitHub response");
+    }
+
+    // Fetch the user to store basic profile
+    const userResp = await fetch("https://api.github.com/user", {
+      headers: { Authorization: `Bearer ${tokenJson.access_token}`, Accept: "application/vnd.github+json" },
+    });
+    let username: string | undefined = undefined;
+    let avatarUrl: string | undefined = undefined;
+    if (userResp.ok) {
+      const userJson = (await userResp.json()) as { login?: string; avatar_url?: string };
+      username = userJson.login;
+      avatarUrl = userJson.avatar_url;
+    }
+
+    return { accessToken: tokenJson.access_token, username, avatarUrl };
+  },
+});
+
+export const listRepos = action({
+  args: { perPage: v.optional(v.number()) },
+  returns: v.array(
+    v.object({
+      id: v.number(),
+      name: v.string(),
+      full_name: v.string(),
+      default_branch: v.string(),
+      clone_url: v.string(),
+      private: v.boolean(),
+      owner: v.object({ login: v.string() }),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new ConvexError({ code: "NotAuthorized", message: "Unauthorized" });
+    const member = await ctx.db
+      .query("convexMembers")
+      .withIndex("byConvexMemberId", (q) => q.eq("convexMemberId", identity.subject))
+      .first();
+    if (!member?.github?.accessToken) return [];
+    const perPage = args.perPage ?? 50;
+    const resp = await fetch(`https://api.github.com/user/repos?per_page=${perPage}&sort=updated`, {
+      headers: { Authorization: `Bearer ${member.github.accessToken}`, Accept: "application/vnd.github+json" },
+    });
+    if (!resp.ok) {
+      throw new Error(`Failed to list repositories: ${await resp.text()}`);
+    }
+    const repos = (await resp.json()) as any[];
+    return repos.map((r) => ({
+      id: r.id,
+      name: r.name,
+      full_name: r.full_name,
+      default_branch: r.default_branch,
+      clone_url: r.clone_url,
+      private: !!r.private,
+      owner: { login: r.owner?.login },
+    }));
+  },
+});
+
+export const downloadRepoArchive = action({
+  args: { fullName: v.string(), ref: v.optional(v.string()) },
+  returns: v.bytes(),
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new ConvexError({ code: "NotAuthorized", message: "Unauthorized" });
+    const member = await ctx.db
+      .query("convexMembers")
+      .withIndex("byConvexMemberId", (q) => q.eq("convexMemberId", identity.subject))
+      .first();
+    if (!member?.github?.accessToken) {
+      throw new ConvexError({ code: "NotAuthorized", message: "No GitHub connection" });
+    }
+    const ref = args.ref ? `/${encodeURIComponent(args.ref)}` : "";
+    const url = `https://api.github.com/repos/${args.fullName}/zipball${ref}`;
+    const resp = await fetch(url, {
+      headers: { Authorization: `Bearer ${member.github.accessToken}`, Accept: "application/vnd.github+json" },
+    });
+    if (!resp.ok) {
+      throw new Error(`Failed to download repository archive: ${await resp.text()}`);
+    }
+    const bytes = await resp.arrayBuffer();
+    return bytes;
+  },
+});
+

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -40,6 +40,13 @@ export default defineSchema({
     apiKey: v.optional(apiKeyValidator),
     convexMemberId: v.optional(v.string()),
     softDeletedForWorkOSMerge: v.optional(v.boolean()),
+    github: v.optional(
+      v.object({
+        accessToken: v.string(),
+        username: v.optional(v.string()),
+        avatarUrl: v.optional(v.string()),
+      }),
+    ),
     // Not authoritative, just a cache of the user's profile from WorkOS/provision host.
     cachedProfile: v.optional(
       v.object({


### PR DESCRIPTION
Add GitHub integration for connecting accounts, listing repositories, and importing them into the workspace, and integrate existing API key management into the new Settings UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-afe74d55-c549-42c9-8419-e6e9f70b9f6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-afe74d55-c549-42c9-8419-e6e9f70b9f6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

